### PR TITLE
Fix link to releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Frostr keyset manager and remote signer.
 
 ### Download Release (Recommended)
 
-Download the latest release for your platform from our [GitHub Releases](https://github.com/austinkelsay/igloo/releases) page.
+Download the latest release for your platform from our [GitHub Releases](https://github.com/FROSTR-ORG/igloo/releases) page.
 
 All releases are GPG signed and include SHA256 checksums for verification. We strongly recommend verifying your download:
 1. See [VERIFICATION.md](VERIFICATION.md) for detailed verification instructions


### PR DESCRIPTION
I noticed that the link to the releases in the README was wrong.