### PR TITLE
buttons more explicity kill Bifrost node

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import ShareList from "@/components/ShareList"
 import Create from "@/components/Create"
 import Keyset from "@/components/Keyset"
-import Signer from "@/components/Signer"
+import Signer, { SignerHandle } from "@/components/Signer"
 import Recover from "@/components/Recover"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -30,6 +30,9 @@ const App: React.FC = () => {
   const [showTooltip, setShowTooltip] = useState(false);
   const [hasShares, setHasShares] = useState(false);
   const [showMainTooltip, setShowMainTooltip] = useState(false);
+  const [activeTab, setActiveTab] = useState("signer");
+  // Reference to the Signer component to call its stop method
+  const signerRef = useRef<SignerHandle>(null);
 
   useEffect(() => {
     // Check if there are any shares saved
@@ -60,8 +63,22 @@ const App: React.FC = () => {
   };
 
   const handleBackToShares = () => {
+    // Stop signer before navigating away
+    if (signerRef.current) {
+      console.log("App: Stopping signer before navigating back to shares");
+      signerRef.current.stopSigner();
+    }
     setSignerData(null);
     setShowingCreate(false);
+  };
+
+  const handleTabChange = (value: string) => {
+    // If switching away from signer tab, stop the signer
+    if (activeTab === "signer" && value !== "signer" && signerRef.current) {
+      console.log("App: Stopping signer before switching to", value, "tab");
+      signerRef.current.stopSigner();
+    }
+    setActiveTab(value);
   };
 
   const handleFinish = () => {
@@ -132,7 +149,12 @@ const App: React.FC = () => {
               </Button>
             </div>
             
-            <Tabs defaultValue="signer" className="w-full">
+            <Tabs 
+              defaultValue="signer" 
+              className="w-full"
+              value={activeTab}
+              onValueChange={handleTabChange}
+            >
               <TabsList className="grid grid-cols-2 mb-4 bg-gray-800/50 w-full">
                 <TabsTrigger value="signer" className="text-sm py-2 text-blue-400 data-[state=active]:bg-blue-900/60 data-[state=active]:text-blue-200">
                   Signer
@@ -143,7 +165,10 @@ const App: React.FC = () => {
               </TabsList>
               
               <TabsContent value="signer" className="border border-blue-900/30 rounded-lg p-4">
-                <Signer initialData={signerData} />
+                <Signer 
+                  initialData={signerData} 
+                  ref={signerRef}
+                />
               </TabsContent>
               
               <TabsContent value="recover" className="border border-purple-900/30 rounded-lg p-4">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -65,7 +65,6 @@ const App: React.FC = () => {
   const handleBackToShares = () => {
     // Stop signer before navigating away
     if (signerRef.current) {
-      console.log("App: Stopping signer before navigating back to shares");
       signerRef.current.stopSigner();
     }
     setSignerData(null);
@@ -75,7 +74,6 @@ const App: React.FC = () => {
   const handleTabChange = (value: string) => {
     // If switching away from signer tab, stop the signer
     if (activeTab === "signer" && value !== "signer" && signerRef.current) {
-      console.log("App: Stopping signer before switching to", value, "tab");
       signerRef.current.stopSigner();
     }
     setActiveTab(value);

--- a/src/components/Signer.tsx
+++ b/src/components/Signer.tsx
@@ -49,44 +49,15 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData }, ref) => {
 
   // Add effect to cleanup on unmount
   useEffect(() => {
-    console.log('Signer component mounted');
-    
     // Cleanup function that runs when component unmounts
     return () => {
-      console.log('Signer component unmounting, cleanup starting...');
       if (isSignerRunning) {
         addLog('info', 'Signer stopped due to page navigation');
         cleanupNode();
         setIsSignerRunning(false);
       }
-      console.log('Signer component unmount cleanup completed');
     };
   }, []);  // Only run on mount/unmount, not when isSignerRunning changes
-
-  // Add heartbeat effect to monitor signer status
-  useEffect(() => {
-    let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
-    
-    if (isSignerRunning) {
-      console.log('🟢 Signer heartbeat started');
-      
-      // Set up interval to log heartbeat every 5 seconds
-      heartbeatInterval = setInterval(() => {
-        const timestamp = new Date().toLocaleTimeString();
-        console.log(`🟢 Signer heartbeat: running at ${timestamp}`);
-      }, 5000);
-    } else {
-      console.log('🔴 Signer heartbeat not running');
-    }
-    
-    // Cleanup interval when component unmounts or signer stops
-    return () => {
-      if (heartbeatInterval) {
-        clearInterval(heartbeatInterval);
-        console.log('🔴 Signer heartbeat interval cleared');
-      }
-    };
-  }, [isSignerRunning]);
 
   // Expose the stopSigner method to parent components through ref
   useImperativeHandle(ref, () => ({
@@ -108,8 +79,6 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData }, ref) => {
   const cleanupNode = () => {
     if (nodeRef.current) {
       try {
-        console.log('Running signer cleanup...');
-        
         // Remove event listeners
         if (nodeRef.current.listeners) {
           const { ready, message, error, disconnect } = nodeRef.current.listeners;
@@ -174,8 +143,6 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData }, ref) => {
         } catch (e) {
           console.warn('Error disconnecting:', e);
         }
-        
-        console.log('Signer cleanup completed');
       } catch (error) {
         console.error('Error during cleanup:', error);
       }

--- a/src/components/Signer.tsx
+++ b/src/components/Signer.tsx
@@ -9,6 +9,29 @@ import { Input } from "@/components/ui/input"
 import { validateShare, validateGroup } from "@/lib/validation"
 import { decode_share, decode_group } from "@/lib/bifrost"
 
+// Add CSS for the pulse animation
+const pulseStyle = `
+  @keyframes pulse {
+    0% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.6;
+      transform: scale(1.1);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  
+  .pulse-animation {
+    animation: pulse 1.5s ease-in-out infinite;
+    box-shadow: 0 0 5px 2px rgba(34, 197, 94, 0.6);
+  }
+`;
+
 interface SignerProps {
   initialData?: {
     share: string;
@@ -380,6 +403,9 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData }, ref) => {
 
   return (
     <div className="space-y-6">
+      {/* Add the pulse style */}
+      <style>{pulseStyle}</style>
+      
       <Card className="bg-gray-900/30 border-blue-900/30 backdrop-blur-sm shadow-lg">
         <CardContent className="p-8 space-y-8">
           <div className="flex items-center">
@@ -447,7 +473,11 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData }, ref) => {
               
               <div className="flex items-center justify-between mt-6">
                 <div className="flex items-center gap-2">
-                  <div className={`w-3 h-3 rounded-full ${isSignerRunning ? 'bg-green-500' : 'bg-red-500'}`}></div>
+                  <div className={`w-3 h-3 rounded-full ${
+                    isSignerRunning 
+                      ? 'bg-green-500 pulse-animation' 
+                      : 'bg-red-500'
+                  }`}></div>
                   <span className="text-gray-300">Signer {isSignerRunning ? 'Running' : 'Stopped'}</span>
                 </div>
                 <Button


### PR DESCRIPTION
Bifrost node can sometimes live on in memory when navigating out of the signer page and even stopping via the signer button. This PR ensures that the signer process and bifrost nodes are explicitly killed when exiting signer page or otherwise stopping signer.

Also adds a pulse animation to green signer light to more explicitly indicate it is running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visual pulse animation to the green status indicator when the signer is running.

- **Improvements**
  - Tabs are now managed with explicit state, ensuring smoother and more predictable navigation.
  - The signer process is automatically stopped when navigating away from the signer tab or returning to the shares list, helping to conserve resources and prevent unnecessary activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->